### PR TITLE
[R4R] update hid dependency to usb

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,14 @@
   version = "v1.1.1"
 
 [[projects]]
+  branch = "master"
+  digest = "1:49ff9e9cebe124fdd184f38369412fa0199669cf0626a79cc9e0cc26848c2824"
+  name = "github.com/karalabe/usb"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "550797b1cad8e44177d2acda8687d4f0ca8501e1"
+
+[[projects]]
   digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
   name = "github.com/pkg/errors"
   packages = ["."]
@@ -26,28 +34,28 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:972c2427413d41a1e06ca4897e8528e5a1622894050e2f527b38ddf0f343f759"
+  digest = "1:8548c309c65a85933a625be5e7d52b6ac927ca30c56869fae58123b8a77a75e1"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
   pruneopts = "UT"
-  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
-  version = "v1.3.0"
+  revision = "221dbe5ed46703ee255b1da0dec05086f5035f62"
+  version = "v1.4.0"
 
 [[projects]]
-  digest = "1:b73f5e117bc7c6e8fc47128f20db48a873324ad5cfeeebfc505e85c58682b5e4"
-  name = "github.com/zondax/hid"
+  digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
+  name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = "T"
-  revision = "302fd402163c34626286195dfa9adac758334acc"
-  version = "v0.9.0"
+  pruneopts = "UT"
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/karalabe/usb",
     "github.com/pkg/errors",
     "github.com/stretchr/testify/assert",
-    "github.com/zondax/hid",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,8 +1,4 @@
 [[constraint]]
-  name = "github.com/zondax/hid"
-  version = "0.9.0"
-
-[[constraint]]
   name = "github.com/pkg/errors"
   version = "0.8.0"
 
@@ -14,5 +10,5 @@
   go-tests = true
   unused-packages = true
   [[prune.project]]
-      name = "github.com/zondax/hid"
+      name = "github.com/karalabe/usb"
       unused-packages = false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ branches:
   only:
     - master
 
-clone_folder: c:\gopath\src\github.com\zondax\ledger-goclient
+clone_folder: c:\gopath\src\github.com\zondax\ledger-go
 
 environment:
   GOPATH: c:\gopath

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ branches:
   only:
     - master
 
-clone_folder: c:\gopath\src\github.com\zondax\ledger-go
+clone_folder: c:\gopath\src\github.com\zondax\ledger-goclient
 
 environment:
   GOPATH: c:\gopath

--- a/ledger.go
+++ b/ledger.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/zondax/hid"
+	"github.com/karalabe/usb"
 )
 
 const (
@@ -33,13 +33,13 @@ const (
 )
 
 type Ledger struct {
-	device      hid.Device
+	device      usb.Device
 	readCo      sync.Once
 	readChannel chan []byte
 	Logging     bool
 }
 
-func NewLedger(dev *hid.Device) *Ledger {
+func NewLedger(dev *usb.Device) *Ledger {
 	return &Ledger{
 		device:  *dev,
 		Logging: false,
@@ -47,7 +47,11 @@ func NewLedger(dev *hid.Device) *Ledger {
 }
 
 func ListDevices() {
-	devices := hid.Enumerate(0, 0)
+	devices, err := usb.Enumerate(0, 0)
+	if err!= nil {
+		fmt.Printf("enumerate devices error, err=%s", err.Error())
+		return
+	}
 
 	if len(devices) == 0 {
 		fmt.Printf("No devices")
@@ -68,7 +72,10 @@ func ListDevices() {
 }
 
 func FindLedger() (*Ledger, error) {
-	devices := hid.Enumerate(VendorLedger, 0)
+	devices, err := usb.Enumerate(VendorLedger, 0)
+	if err != nil {
+		return nil, err
+	}
 
 	for _, d := range devices {
 		deviceFound := d.UsagePage == UsagePageLedger
@@ -77,7 +84,7 @@ func FindLedger() (*Ledger, error) {
 		if deviceFound {
 			device, err := d.Open()
 			if err == nil {
-				return NewLedger(device), nil
+				return NewLedger(&device), nil
 			}
 		}
 	}

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -22,12 +22,13 @@ import (
 	"encoding/hex"
 	"fmt"
 	"github.com/stretchr/testify/assert"
-	"github.com/zondax/hid"
+	"github.com/karalabe/usb"
 	"testing"
 )
 
 func Test_ThereAreDevices(t *testing.T) {
-	devices := hid.Enumerate(0, 0)
+	devices, err := usb.Enumerate(0, 0)
+	assert.Nil(t, err, "err should be nil")
 	assert.NotEqual(t, 0, len(devices))
 }
 

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -21,9 +21,10 @@ package ledger_go
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/karalabe/usb"
 	"testing"
+
+	"github.com/karalabe/usb"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_ThereAreDevices(t *testing.T) {


### PR DESCRIPTION
Because go-ethereum import lib: https://github.com/karalabe/usb, so if some one want to import this repo at the same time, errors will occur when compiling project.

Ref: https://github.com/binance-chain/go-sdk/issues/86