### PR TITLE
fix device lookup on linux, as usage page is not available.

### DIFF
--- a/ledger_hid.go
+++ b/ledger_hid.go
@@ -45,6 +45,7 @@ type LedgerDeviceHID struct {
 var supportedLedgerProductID = map[uint16]int{
 	0x4011: 0, // Ledger Nano X
 	0x1011: 0, // Ledger Nano S
+	0x1:    0, // Ledger Nano S
 }
 
 func NewLedgerAdmin() *LedgerAdminHID {


### PR DESCRIPTION
Closes https://github.com/Zondax/ledger-go/issues/19

From https://github.com/Zondax/hid/blob/5552068d2266b80f57f74bd4cf4b9c366f2c7918/hidapi/libusb/hid.c#L596
usage page is not available in linux per default in the used hidapi version. So device is not found. Also due that the ProductID changes for the tested app (avalanche). Executions on mac and linux shows that ProductID seems to be 1 for ledger nano S when the app is activated. So this seems to be a good workaround.

Other options (both for github.com/Zondax/hid/), besides this PR, may be:
- define INVASIVE_GET_USAGE in https://github.com/Zondax/hid/blob/master/hidapi/libusb/hid.c (accepting the invaside stuff) and check if we get expected usage page
- use the hidapi hid.c that uses web wallet (which seems to be older than the one in zondax repo), https://github.com/libusb/hidapi/blob/f6d0073fcddbdda24549199445e844971d3c9cef/linux/hid.c, that obtains the usage page, and, strange enough, does not seem to do the invasive stuff refered to in the zondax repo version (detach and re-attach of kernel driver) (it also seems the last version in https://github.com/libusb/hidapi/ also does not mention that kernel driver stuff)