### PR TITLE
Remove suprious OSX USB Reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 *.dylib
 *.dll
 
+# Fortran module files - Why? For now, Allow go.mod
+#*.mod
+
 # Fortran module files
 *.smod
 

--- a/apduWrapper.go
+++ b/apduWrapper.go
@@ -53,7 +53,7 @@ func ErrorMessage(errorCode uint16) string {
 	case 0x6E00:
 		return "[APDU_CODE_CLA_NOT_SUPPORTED] CLA not supported"
 	case 0x6E01:
-		return "[0x6E01] Ledger Connected but Cosmos App Not Open"
+		return "[0x6E01] Ledger Connected but Chain Specific App Not Open"
 	case 0x6F00:
 		return "APDU_CODE_UNKNOWN"
 	case 0x6F01:

--- a/apduWrapper.go
+++ b/apduWrapper.go
@@ -53,7 +53,7 @@ func ErrorMessage(errorCode uint16) string {
 	case 0x6E00:
 		return "[APDU_CODE_CLA_NOT_SUPPORTED] CLA not supported"
 	case 0x6E01:
-		return "[0x6E01] Ledger Connected but Chain Specific App Not Open"
+		return "[APDU_CODE_APP_NOT_OPEN] Ledger Connected but Chain Specific App Not Open"
 	case 0x6F00:
 		return "APDU_CODE_UNKNOWN"
 	case 0x6F01:

--- a/apduWrapper.go
+++ b/apduWrapper.go
@@ -195,6 +195,9 @@ func UnwrapResponseAPDU(channel uint16, pipe <-chan []byte, packetSize int) ([]b
 		buffer := <-pipe
 
 		result, responseSize, isSequenceZero, err = DeserializePacket(channel, buffer, sequenceIdx) // this may fail if the wrong sequence arrives (espeically if left over all 0000 was in the buffer from the last tx)
+		if err != nil {
+			return nil, err
+		}
 
 		// Recover from a known error condition:
 		// * Discard messages left over from previous exchange until isSequenceZero == true
@@ -202,10 +205,6 @@ func UnwrapResponseAPDU(channel uint16, pipe <-chan []byte, packetSize int) ([]b
 			continue
 		}
 		foundZeroSequence = true
-
-		if err != nil {
-			return nil, err
-		}
 
 		// Initialize totalSize (previously we did this if sequenceIdx == 0, but sometimes Nano X can provide the first sequenceIdx == 0 packet with all zeros, then a useful packet with sequenceIdx == 1
 		if totalSize == 0 {

--- a/apduWrapper_test.go
+++ b/apduWrapper_test.go
@@ -211,11 +211,12 @@ func Test_DeserializePacket_FirstPacket(t *testing.T) {
 	var firstPacketHeaderSize = 7
 	packet, _, _ := SerializePacket(0x0101, sampleCommand, packetSize, 0)
 
-	output, totalSize, err := DeserializePacket(0x0101, packet, 0)
+	output, totalSize, isSequenceZero, err := DeserializePacket(0x0101, packet, 0)
 
 	assert.Nil(t, err, "Simple deserialize should not have errors")
 	assert.Equal(t, len(sampleCommand), int(totalSize), "TotalSize is incorrect")
 	assert.Equal(t, packetSize-firstPacketHeaderSize, len(output), "Size of the deserialized packet is wrong")
+	assert.Equal(t, true, isSequenceZero, "Test Case Should Find Sequence == 0")
 	assert.True(t, bytes.Compare(output[:len(sampleCommand)], sampleCommand) == 0, "Deserialized message does not match the original")
 }
 
@@ -226,11 +227,12 @@ func Test_DeserializePacket_SecondMessage(t *testing.T) {
 	var firstPacketHeaderSize = 5 // second packet does not have responseLength (uint16) in the header
 	packet, _, _ := SerializePacket(0x0101, sampleCommand, packetSize, 1)
 
-	output, totalSize, err := DeserializePacket(0x0101, packet, 1)
+	output, totalSize, isSequenceZero, err := DeserializePacket(0x0101, packet, 1)
 
 	assert.Nil(t, err, "Simple deserialize should not have errors")
 	assert.Equal(t, 0, int(totalSize), "TotalSize should not be returned from deserialization of non-first packet")
 	assert.Equal(t, packetSize-firstPacketHeaderSize, len(output), "Size of the deserialized packet is wrong")
+	assert.Equal(t, false, isSequenceZero, "Test Case Should Find Sequence == 1")
 	assert.True(t, bytes.Equal(output[:len(sampleCommand)], sampleCommand), "Deserialized message does not match the original")
 }
 

--- a/ledger_hid.go
+++ b/ledger_hid.go
@@ -60,7 +60,7 @@ func (admin *LedgerAdminHID) ListDevices() ([]string, error) {
 	devices := hid.Enumerate(0, 0)
 
 	if len(devices) == 0 {
-		fmt.Printf("No devices. Ledger LOCKED OR Keplr/Ledger Live may have control of device.")
+		fmt.Printf("No devices. Ledger LOCKED OR Other Program/Web Browser may have control of device.")
 	}
 
 	for _, d := range devices {
@@ -131,7 +131,7 @@ func (admin *LedgerAdminHID) Connect(requiredIndex int) (LedgerDevice, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("LedgerHID device (idx %d) not found. Ledger LOCKED OR Keplr/Ledger Live may have control of device", requiredIndex)
+	return nil, fmt.Errorf("LedgerHID device (idx %d) not found. Ledger LOCKED OR Other Program/Web Browser may have control of device.", requiredIndex)
 }
 
 func (ledger *LedgerDeviceHID) write(buffer []byte) (int, error) {

--- a/ledger_hid.go
+++ b/ledger_hid.go
@@ -173,7 +173,7 @@ func (ledger *LedgerDeviceHID) readThread() {
 
 		// Discard all zero packets from Ledger Nano X on macOS
 		allZeros := true
-		for i := 0; i < 64; i++ {
+		for i := 0; i < len(buffer); i++ {
 			if buffer[i] != 0 {
 				allZeros = false
 				break


### PR DESCRIPTION
Porting PR from: https://github.com/cosmos/ledger-go/pull/7

## Transaction approval with Ledger + OS X often fails due to:

Packets full of zeros being read
Packets out of sequence being read
This patch filters all zero filled packets and ensures each USB exchange (Send + Receive) start on proper sequence boundaries.

## Typical Errors - Various chains
Error: len < 2

## Modern Error

juno v11.0.0 with :
  github.com/zondax/ledger-go v0.14.0 
  github.com/cosmos/ledger-cosmos-go v0.12.0
```
Error: Invalid channel
```

Replaced with this branch - Eliminates error

--

Previous tester feedback on cosmos/ledger-go PR based code:

https://twitter.com/KevinGarrison/status/1588151637432012800
https://twitter.com/rhinostake/status/1588161469623013377
